### PR TITLE
fix: syntax path and char range tokens

### DIFF
--- a/syntaxes/ignore.tmLanguage.json
+++ b/syntaxes/ignore.tmLanguage.json
@@ -58,11 +58,11 @@
 					"match": "\\*\\*|[*?]"
 				},
 				{
-					"name": "string.quoted.other",
+					"name": "keyword.control.ignore",
 					"match": "/"
 				},
 				{
-					"name": "string.quoted.other",
+					"name": "keyword.control.ignore",
 					"match": "\\."
 				},
 				{
@@ -85,10 +85,14 @@
 					"name": "markup.punctuation.quote.beginning.end.ignore"
 				}
 			},
-			"contentName": "constant.other.character-class.range.ignore",
+			"contentName": "string.regexp.ignore",
 			"patterns": [
 				{
 					"include": "#escape"
+				},
+				{
+					"name": "constant.character",
+					"match": "-"
 				}
 			]
 		},


### PR DESCRIPTION
I forgot about the char range thing when i fixed the syntax tokens.

and i think the path `/` looks better with the `keyword.control` (`OPT 1`) token, `OPT 2` is using the `keyword.operator.new` token, i think `OPT 1` is the most readable version, but let me know if you prefer `OPT 2`.

![vscode-ignore-syntax_awd](https://user-images.githubusercontent.com/46901787/179235695-d8bfc58f-2078-43bd-a9ac-999dd700e921.png)

