### PR TITLE
chore: ignore more files from `vsix`

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,7 +1,13 @@
 .vscode/
 src/
 tests/
+
 .gitignore
+.prettierignore
 .prettierrc
+config.json
 tsconfig.json
+tsup.config.ts
+eslint.config.mjs
+pnpm-lock.yaml
 TODO.md


### PR DESCRIPTION
before: 14 files
<img width="1087" height="557" alt="image" src="https://github.com/user-attachments/assets/900e7349-6ea1-4a46-805a-141f535bd4f5" />

after: 9 files
<img width="1070" height="398" alt="image" src="https://github.com/user-attachments/assets/edaca7de-cb6c-4da7-8aba-00c4e91f4f7c" />
